### PR TITLE
package: make all devDependencies just dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "15.5.4",
     "react-dom": "15.6.0"
   },
+  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/eins78/npm-globals.git"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "author": "Max F. Albrecht <1@178.is>",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "babel-cli": "6.26.0",
     "browserify": "14.3.0",
     "cheerio-cli": "0.1.0",
@@ -32,9 +32,7 @@
     "semantic-release-cli": "3.0.3",
     "serve": "5.1.5",
     "standard": "10.0.3",
-    "yo": "2.0.0"
-  },
-  "dependencies": {
+    "yo": "2.0.0",
     "async": "2.4.0",
     "lodash": "4.17.4",
     "react": "15.5.4",


### PR DESCRIPTION
otherwise greenkeeper (rightfully) only regards it as a 'chore' and semantic-release does not publish a new version